### PR TITLE
Add User-Agent tracking and align Python client docs with Swagger API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ This will install the `g2papi` package and its dependencies.
 
 You can import `g2papi` in your Python scripts to retrieve data from the G2P API directly. Here are some examples:
 
-Calling the G2P3D API to get the Gene-Transcript-Protein Isoform-Structure mapping
+#### Gene-Transcript-Protein Isoform-Structure Mapping
+
+> **Swagger endpoint:** `GET /api/gene/{geneName}/protein/{uniprotId}/gene-transcript-protein-isoform-structure-map` — [Try it on Swagger UI](https://g2p.broadinstitute.org/api-docs/)
 
 ```python
 import g2papi
@@ -85,7 +87,9 @@ Output:
 4     P38398-1(*)    ENST00000357654(*)   NM_001407641
 ```
 
-Getting Protein Features
+#### Protein Features
+
+> **Swagger endpoint:** `GET /api/gene/{geneName}/protein/{uniprotId}/protein-features` — [Try it on Swagger UI](https://g2p.broadinstitute.org/api-docs/)
 
 ```python
 import g2papi
@@ -112,7 +116,9 @@ Output:
 4          5  A                            61.73                     -
 ```
 
-Getting Isoform Alignment
+#### Isoform Sequence Alignment
+
+> **Swagger endpoint:** `GET /api/gene/{geneName}/protein/{canonicalIsoformUniprotId}/{alignmentIsoformUniprotId}/alignment` — [Try it on Swagger UI](https://g2p.broadinstitute.org/api-docs/)
 
 ```python
 import g2papi
@@ -142,13 +148,13 @@ Output:
 ### As a Command-Line Tool
 g2papi can also be used as a command-line tool to retrieve information directly to your terminal or output files.
 
-Getting Gene-Transcript-Protein Isoform-Structure Map with the G2P3D API
+#### Gene-Transcript-Protein Isoform-Structure Map
 
 ```
 g2papi get-gene-transcript-protein-isoform-structure-map --geneName BRCA1 --uniprotId P38398
 ```
 
-Getting Protein Features
+#### Protein Features
 
 ```
 g2papi get-protein-features --geneName BRCA1 --uniprotId P38398

--- a/g2papi/__init__.py
+++ b/g2papi/__init__.py
@@ -1,1 +1,1 @@
-from .api import get_gene_transcript_protein_isoform_structure, get_protein_features
+from .api import get_gene_transcript_protein_isoform_structure, get_protein_features, get_isoform_sequence_alignment

--- a/g2papi/api.py
+++ b/g2papi/api.py
@@ -1,25 +1,44 @@
 import requests
 import pandas as pd
 from io import StringIO
+from importlib.metadata import version as _pkg_version
 
 HOST = "https://g2p.broadinstitute.org"
 BASE_URL = HOST + "/api/gene/{}/protein/{}/{}"
 ALIGNMENT_URL = HOST + "/api/gene/{}/protein/{}/{}/alignment"
 
+try:
+    _VERSION = _pkg_version("g2papi")
+except Exception:
+    _VERSION = "unknown"
+
+_HEADERS = {"User-Agent": f"g2papi-python/{_VERSION}"}
+
+
 def get_gene_transcript_protein_isoform_structure(geneName, uniprotId):
+    """Retrieve the gene-transcript-protein isoform-structure mapping.
+
+    Swagger endpoint:
+        GET /api/gene/{geneName}/protein/{uniprotId}/gene-transcript-protein-isoform-structure-map
+        https://g2p.broadinstitute.org/api-docs/
+    """
     url = BASE_URL.format(geneName, uniprotId, "gene-transcript-protein-isoform-structure-map")
-    response = requests.get(url)
-    response.raise_for_status()  # Raise an error for bad responses
-    
-    # Use StringIO to turn the response text into a file-like object
+    response = requests.get(url, headers=_HEADERS)
+    response.raise_for_status()
+
     csv_data = StringIO(response.text)
-    
     return pd.read_csv(csv_data, sep='\t')
 
 
 def get_protein_features(geneName, uniprotId):
+    """Retrieve the protein feature table for a gene.
+
+    Swagger endpoint:
+        GET /api/gene/{geneName}/protein/{uniprotId}/protein-features
+        https://g2p.broadinstitute.org/api-docs/
+    """
     url = BASE_URL.format(geneName, uniprotId, "protein-features")
-    response = requests.get(url)
+    response = requests.get(url, headers=_HEADERS)
     response.raise_for_status()
 
     csv_data = StringIO(response.text)
@@ -27,8 +46,14 @@ def get_protein_features(geneName, uniprotId):
 
 
 def get_isoform_sequence_alignment(geneName, canonicalIsoformUniprotId, alignmentIsoformUniprotId):
+    """Retrieve isoform sequence alignment between canonical and alternative isoforms.
+
+    Swagger endpoint:
+        GET /api/gene/{geneName}/protein/{canonicalIsoformUniprotId}/{alignmentIsoformUniprotId}/alignment
+        https://g2p.broadinstitute.org/api-docs/
+    """
     url = ALIGNMENT_URL.format(geneName, canonicalIsoformUniprotId, alignmentIsoformUniprotId)
-    response = requests.get(url)
+    response = requests.get(url, headers=_HEADERS)
     response.raise_for_status()
 
     csv_data = StringIO(response.text)


### PR DESCRIPTION
## Summary                                               

- Add custom `User-Agent` header (`g2papi-python/<version>`) to all API requests for usage tracking via App Engine Cloud Logging                   
- Export missing `get_isoform_sequence_alignment` from  `__init__.py`                                            
- Add docstrings with Swagger endpoint references to all API functions                                            
- Improve README subheaders and add Swagger endpoint links for consistency                                    
                                                         
Closes[ #1432  ](https://github.com/broadinstitute/Genomics2Proteins_portal/issues/1432)